### PR TITLE
Fixing Flex bug (reproducible on Safari)

### DIFF
--- a/src/components/order/MenuSearch.tsx
+++ b/src/components/order/MenuSearch.tsx
@@ -38,7 +38,11 @@ const MenuSearch: FC<Props> = ({
         className="flex justify-between br2 pt3 ph3 shadow-2 mb2"
         style={{ backgroundColor: '#f0f2f5' }}
       >
-        <Form.Item label="Categoria" className="w-40 mr2">
+        <Form.Item
+          label="Categoria"
+          className="w-40 mr2"
+          style={{ display: 'unset' }}
+        >
           <Select
             getPopupContainer={(trigger) => trigger.parentElement}
             value={activeSection}
@@ -52,7 +56,12 @@ const MenuSearch: FC<Props> = ({
             ))}
           </Select>
         </Form.Item>
-        <Form.Item label="Busca" name="searchTerm" className="w-60">
+        <Form.Item
+          label="Busca"
+          name="searchTerm"
+          className="w-60"
+          style={{ display: 'unset' }}
+        >
           <Input
             allowClear
             suffix={loading && <LoadingOutlined />}

--- a/src/components/tenant/products/ProductForm.tsx
+++ b/src/components/tenant/products/ProductForm.tsx
@@ -266,12 +266,14 @@ const ProductForm: FC<Props> = ({
         <div className="flex justify-around flex-auto w-100 w-auto-l">
           <Item
             label={<Message id="tenant.product.min" />}
+            style={{ display: 'unset' }}
             name="min"
             rules={rules.min}
           >
             <NumberInput min={0} disabled={loading} />
           </Item>
           <Item
+            style={{ display: 'unset' }}
             label={<Message id="tenant.product.max" />}
             name="max"
             rules={[


### PR DESCRIPTION

Before:
![image](https://user-images.githubusercontent.com/18706156/94133426-017f5580-fe37-11ea-9513-107b0ce36608.png)

After:
![image](https://user-images.githubusercontent.com/18706156/94133464-10660800-fe37-11ea-9a7d-f6c3fe95085e.png)

Also fixed the same problem on the min/max form items on Product Form.

I have to confess that I don't know why this happens.. It's only on **Safari or Chrome on my mobile**.