### PR TITLE
Add a "Go to Shipping" button on fixed Totalizer

### DIFF
--- a/src/components/Order.tsx
+++ b/src/components/Order.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useMemo, Fragment } from 'react'
+import React, { FC, useCallback, useMemo, Fragment, useState } from 'react'
 import { Affix, Alert, Button, Form, Divider, Input, Spin, Layout } from 'antd'
 import { SendOutlined } from '@ant-design/icons'
 import * as firebase from 'firebase/app'
@@ -43,6 +43,7 @@ const Order: FC = () => {
   const { tenant, loading, products } = useTenantConfig()
   const [{ order }, dispatch] = useOrder()
   const shippingAddress = order?.shipping?.address
+  const [isAddressOnViewport, setAddressOnViewport] = useState(false)
 
   // Dirty hack to initially select a shipping method
   useInitialShipping(tenant, order, dispatch)
@@ -204,6 +205,7 @@ const Order: FC = () => {
                     layout="vertical"
                   >
                     <SelectShipping
+                      onViewPort={(isIt) => setAddressOnViewport(isIt)}
                       onAutoFill={(data: Partial<WorldAddress>) => {
                         orderForm.setFieldsValue({ ...data })
                       }}
@@ -225,7 +227,10 @@ const Order: FC = () => {
                     {!!order?.items.length && (
                       <>
                         <Affix offsetBottom={-5} className="mt4">
-                          <Totalizer order={order} />
+                          <Totalizer
+                            order={order}
+                            shouldDisplayButton={!isAddressOnViewport}
+                          />
                         </Affix>
                         <OrderSummary order={order} />
                         <Divider />

--- a/src/components/Order.tsx
+++ b/src/components/Order.tsx
@@ -205,10 +205,8 @@ const Order: FC = () => {
                     layout="vertical"
                   >
                     <SelectShipping
+                      id="shipping-selector"
                       onViewPort={(isIt) => setAddressOnViewport(isIt)}
-                      onAutoFill={(data: Partial<WorldAddress>) => {
-                        orderForm.setFieldsValue({ ...data })
-                      }}
                     />
                     <Divider />
                     <Item name="info" label="Outras informações?">

--- a/src/components/Totalizer.tsx
+++ b/src/components/Totalizer.tsx
@@ -47,7 +47,24 @@ const Totalizer = React.forwardRef<HTMLDivElement, Props>(
             </span>
           </div>
         </div>
-        <GoDownButton shouldDisplay={!!shouldDisplayButton}>
+        <GoDownButton
+          shouldDisplay={!!shouldDisplayButton}
+          onClick={() => {
+            const el = document.getElementById('shipping-selector')
+
+            if (!el) {
+              return
+            }
+
+            const yOffSet = -110
+            const y =
+              (el?.getBoundingClientRect().top || 0) +
+              window.pageYOffset +
+              yOffSet
+
+            window.scrollTo({ top: y, behavior: 'smooth' })
+          }}
+        >
           {formatMessage({ id: 'order.totalizer.goToShipping' })}
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Totalizer.tsx
+++ b/src/components/Totalizer.tsx
@@ -1,14 +1,18 @@
+import { styled } from 'linaria/react'
 import React from 'react'
 
+import { useAltIntl } from '../intlConfig'
 import { Order } from '../typings'
 import Real from './Real'
 
 type Props = {
   order: Order | null
+  shouldDisplayButton?: boolean
 }
 
 const Totalizer = React.forwardRef<HTMLDivElement, Props>(
-  function WrappedTotalizer({ order }, ref) {
+  function WrappedTotalizer({ order, shouldDisplayButton }, ref) {
+    const { formatMessage } = useAltIntl()
     const selectedMethod = order?.shipping?.type
     const isDelivery = selectedMethod === 'DELIVERY'
     const isTakeaway = selectedMethod === 'TAKEAWAY'
@@ -16,19 +20,26 @@ const Totalizer = React.forwardRef<HTMLDivElement, Props>(
     const fee = order?.shipping?.price ?? 0
 
     return (
-      <div ref={ref} className="flex justify-center w-100">
-        <div className="w-100 bg-washed-blue h-100 pa3 br3 shadow-2">
+      <div
+        ref={ref}
+        className="flex flex-column items-center w-100 bg-washed-blue h-100 pa3 br3 shadow-2"
+      >
+        <div className="w-100">
           <div className="flex justify-between items-center">
             <div className="flex flex-column justify-center">
-              <b>Total:</b>
+              <b>{formatMessage({ id: 'order.totalizer.total' })}</b>
               <span className="light-silver f6">
-                {isTakeaway && `Retirada Grátis`}
+                {isTakeaway &&
+                  formatMessage({ id: 'order.totalizer.freeTakeaway' })}
                 {isDelivery && fee > 0 && (
                   <span>
-                    Entrega: <Real cents={fee} />
+                    {formatMessage({ id: 'order.totalizer.delivery' })}
+                    <Real cents={fee} />
                   </span>
                 )}
-                {isDelivery && fee === 0 && 'Entrega Grátis'}
+                {isDelivery &&
+                  fee === 0 &&
+                  formatMessage({ id: 'order.totalizer.freeShipping' })}
               </span>
             </div>
             <span className="f4 b">
@@ -36,9 +47,41 @@ const Totalizer = React.forwardRef<HTMLDivElement, Props>(
             </span>
           </div>
         </div>
+        <GoDownButton shouldDisplay={!!shouldDisplayButton}>
+          {formatMessage({ id: 'order.totalizer.goToShipping' })}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            fill="#FFF"
+            className="pl1"
+            viewBox="0 0 451.847 451.847"
+          >
+            <path d="M225.923 354.706c-8.098 0-16.195-3.092-22.369-9.263L9.27 151.157c-12.359-12.359-12.359-32.397 0-44.751 12.354-12.354 32.388-12.354 44.748 0l171.905 171.915 171.906-171.909c12.359-12.354 32.391-12.354 44.744 0 12.365 12.354 12.365 32.392 0 44.751L248.292 345.449c-6.177 6.172-14.274 9.257-22.369 9.257z" />
+          </svg>
+        </GoDownButton>
       </div>
     )
   }
 )
+
+const GoDownButton = styled.button<{ shouldDisplay: boolean }>`
+  &:hover {
+    background-color: #01213f;
+  }
+  background-color: #001529;
+  color: white;
+  border-radius: 10px;
+  padding: 5px;
+  border: 0;
+  font-size: 12px;
+  padding: 3px 10px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-items: center;
+  transition: opacity 0.2s;
+  opacity: ${(props) => (props.shouldDisplay ? '1' : '0')};
+`
 
 export default Totalizer

--- a/src/components/order/SelectShipping.tsx
+++ b/src/components/order/SelectShipping.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import React, { FC, useState, useEffect } from 'react'
+import React, { FC, useState, useEffect, useRef } from 'react'
 import { Form, Radio, Divider } from 'antd'
 
 import { useAltIntl, Message, IntlRules, prepareRules } from '../../intlConfig'
@@ -11,19 +11,21 @@ import { TakeawayIcon } from '../../assets/TakeawayIcon'
 import { generateGoogleMapsLink } from '../../utils'
 import AddressDisplay from '../common/AddressDisplay'
 import OrderAddress from './OrderAddress'
+import { useObserver } from '../../hooks/useObserver'
 
 const { Group } = Radio
 const { Item } = Form
 
 type Props = {
   onAutoFill: (data: Partial<WorldAddress>) => void
+  onViewPort: (isIt: boolean) => void
 }
 
 const intlRules: IntlRules = {
   shippingMethod: [{ required: true, message: 'order.shipping.rule' }],
 }
 
-const SelectShipping: FC<Props> = ({ onAutoFill }) => {
+const SelectShipping: FC<Props> = ({ onAutoFill, onViewPort }) => {
   const { tenant } = useTenantConfig()
   const acceptsTakeaway = tenant?.shippingStrategies?.takeaway?.active
   const acceptsDelivery = tenant?.shippingStrategies?.deliveryFixed?.active
@@ -44,11 +46,13 @@ const SelectShipping: FC<Props> = ({ onAutoFill }) => {
   }, [setCurrent, initialValue, current])
 
   const intl = useAltIntl()
-
   const rules = prepareRules(intlRules, intl)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useObserver(ref, '0px 0px -100px 0px', onViewPort)
 
   return (
-    <div className="flex flex-column">
+    <div className="flex flex-column" ref={ref}>
       <Divider>
         <h2 className="tc">
           {intl.formatMessage({ id: 'order.shippingMethod' })}

--- a/src/components/order/SelectShipping.tsx
+++ b/src/components/order/SelectShipping.tsx
@@ -3,7 +3,7 @@ import React, { FC, useState, useEffect, useRef } from 'react'
 import { Form, Radio, Divider } from 'antd'
 
 import { useAltIntl, Message, IntlRules, prepareRules } from '../../intlConfig'
-import { WorldAddress, ShippingMethod } from '../../typings'
+import { ShippingMethod } from '../../typings'
 import { useTenantConfig } from '../../contexts/TenantContext'
 import addressIcon from '../../assets/address.svg'
 import { DeliveryIcon } from '../../assets/DeliveryIcon'
@@ -17,15 +17,15 @@ const { Group } = Radio
 const { Item } = Form
 
 type Props = {
-  onAutoFill: (data: Partial<WorldAddress>) => void
   onViewPort: (isIt: boolean) => void
+  id: string
 }
 
 const intlRules: IntlRules = {
   shippingMethod: [{ required: true, message: 'order.shipping.rule' }],
 }
 
-const SelectShipping: FC<Props> = ({ onAutoFill, onViewPort }) => {
+const SelectShipping: FC<Props> = ({ id, onViewPort }) => {
   const { tenant } = useTenantConfig()
   const acceptsTakeaway = tenant?.shippingStrategies?.takeaway?.active
   const acceptsDelivery = tenant?.shippingStrategies?.deliveryFixed?.active
@@ -52,7 +52,7 @@ const SelectShipping: FC<Props> = ({ onAutoFill, onViewPort }) => {
   useObserver(ref, '0px 0px -100px 0px', onViewPort)
 
   return (
-    <div className="flex flex-column" ref={ref}>
+    <div className="flex flex-column" ref={ref} id={id}>
       <Divider>
         <h2 className="tc">
           {intl.formatMessage({ id: 'order.shippingMethod' })}

--- a/src/hooks/useObserver.ts
+++ b/src/hooks/useObserver.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react'
+
+export const useObserver = (
+  ref: React.RefObject<any>,
+  rootMargin: string,
+  cb: (isIt: boolean) => void
+) => {
+  useEffect(() => {
+    if (!ref?.current) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          cb(entry.isIntersecting)
+        })
+      },
+      { rootMargin }
+    )
+
+    observer.observe(ref.current)
+
+    return () => {
+      ref?.current && observer.unobserve(ref?.current)
+    }
+  }, [ref, cb])
+}

--- a/src/intlConfig.tsx
+++ b/src/intlConfig.tsx
@@ -314,6 +314,12 @@ export const intlConfig = {
       'Ao preencher seu endereço manualmente você não conseguirá usar a funcionalidade Preço de Entrega Dinâmico',
     'selectAddress.backToSeach': 'voltar para busca',
     'selectAddress.fillManually': 'preencha manualmente',
+    or: 'ou',
+    'order.totalizer.total': 'Total:',
+    'order.totalizer.delivery': 'Entrega: ',
+    'order.totalizer.freeTakeaway': 'Retirada Grátis',
+    'order.totalizer.freeShipping': 'Entrega Grátis',
+    'order.totalizer.goToShipping': 'Ir para Entrega',
   },
 }
 


### PR DESCRIPTION
When in a catalog with a lot of products, the user has to scroll all the way down to finish the order.

This PR adds a button that helps her do that.

Fixes #22 

![image](https://user-images.githubusercontent.com/18706156/99528165-a40e0d80-297c-11eb-8fc8-7b148eb99c7c.png)
